### PR TITLE
fix @dataclass subclasses of TestCase in 3.9

### DIFF
--- a/ts_ci/interface.py
+++ b/ts_ci/interface.py
@@ -3,17 +3,21 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from __future__ import annotations
-from abc import abstractmethod, ABC
-from collections import abc
+from abc import abstractmethod
+from collections.abc import Hashable
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from typing import Protocol
 
 from .backends import HardwareBackend
 
 
-# expects eq, ordering, hashing...
-class TestCase(abc.Hashable, ABC):
+# expects eq, ordering, hashing... but we unfortunately cannot make these
+# @abstractmethod as this creates inheritance issues with dataclasses, which
+# was why `abc.update_abstractmethods` was added in Python 3.10.
+# we also want a 'no_output_timeout_s' property, but we cannot check this.
+class TestCase(Protocol):
     @abstractmethod
     async def run(self, HardwareBackend) -> None: ...
 
@@ -26,13 +30,8 @@ class TestCase(abc.Hashable, ABC):
     @abstractmethod
     def backend(self, loader_img: Path) -> HardwareBackend: ...
 
+    """Timeout in seconds for no output watchdog"""
     no_output_timeout_s: int
-    # property: no_output_timeout_s: int
-    # abstractproperties are broken
-    # Timeout in seconds for no output watchdog"""
 
     @abstractmethod
     def log_file_path(self, logs_dir: Path, now: datetime) -> Path: ...
-
-    @abstractmethod
-    def __lt__(self, other: TestCase) -> bool: ...

--- a/ts_ci/stream_watchdog.py
+++ b/ts_ci/stream_watchdog.py
@@ -1,7 +1,7 @@
 import asyncio
 import enum
 
-from types import TracebackType
+from types import TracebackType, MethodType
 from typing import final, Optional, Type
 
 from .backends import TeeOut
@@ -16,6 +16,43 @@ class _State(enum.Enum):
     EXPIRING = "expiring"
     EXPIRED = "expired"
     EXITED = "finished"
+
+
+# for python <3.11 support
+def _monkeypatch_task(task: asyncio.Task):
+    if hasattr(asyncio.Task, "cancelling"):
+        # already supported
+        return task
+
+    task._num_cancels_requested = 0  # type: ignore[attr-defined]
+
+    original_cancel = task.__class__.cancel
+
+    # Matching https://github.com/python/cpython/blob/3.13/Lib/asyncio/tasks.py#L221-L223
+    def cancel(self, *args, **kwargs):
+        if not self.done():
+            self._num_cancels_requested += 1
+
+        original_cancel(self, *args, **kwargs)
+
+    def cancelling(self):
+        return self._num_cancels_requested
+
+    def uncancel(self):
+        # The _must_cancel still exists in 3.9
+        # https://github.com/python/cpython/blob/3.9/Lib/asyncio/tasks.py#L234-L237
+        # Now: https://github.com/python/cpython/blob/3.13/Lib/asyncio/tasks.py#L256C1-L260C43
+        if self._num_cancels_requested > 0:
+            self._num_cancels_requested -= 1
+            if self._num_cancels_requested == 0:
+                self._must_cancel = False
+        return self._num_cancels_requested
+
+    task.cancel = MethodType(cancel, task)  # type: ignore[method-assign]
+    task.uncancel = MethodType(uncancel, task)  # type: ignore[assignment]
+    task.cancelling = MethodType(cancelling, task)  # type: ignore[method-assign]
+
+    return task
 
 
 @final
@@ -52,7 +89,7 @@ class StreamWatchdog:
         if task is None:
             raise RuntimeError("StreamWatchdog should be used inside a task")
         self._state = _State.ENTERED
-        self._task = task
+        self._task = _monkeypatch_task(task)
         self._tee.touch()
         self._cancelling = self._task.cancelling()
         self._watchdog_kick()


### PR DESCRIPTION
Solves error in Python 3.9:

    TypeError: Can't instantiate abstract class TestConfig
    with abstract methods __hash__, __lt__

Because `@dataclass` does not have the ability to call an equivalent of abc.update_abstractmethods(cls)...