### PR TITLE
Drop Python 3.9 support as EOL since 2025-10-31

### DIFF
--- a/.github/workflows/local-checks.yaml
+++ b/.github/workflows/local-checks.yaml
@@ -45,8 +45,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # oldest python version we support is 3.9
-        version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.x']
+        # oldest python version we support is 3.10
+        version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.x']
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -68,8 +68,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # oldest python version we support is 3.9
-        version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.x']
+        # oldest python version we support is 3.10
+        version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.x']
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/ts_ci/README.md
+++ b/ts_ci/README.md
@@ -10,7 +10,7 @@ system that has the following requirements:
 - Interacting testing over serial.
 - Produces log files for all actions for later viewing.
 
-We target Python 3.9 for compatibility with our macOS runner.
+We target the oldest non-EOL Python version, which is currently 3.10.
 
 ## Supporting a new project
 

--- a/ts_ci/pyproject.toml
+++ b/ts_ci/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ts_ci"
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 readme = "README.md"
 dynamic = ["version"]
 


### PR DESCRIPTION
See associated sDDF PR:
https://github.com/au-ts/sddf/pull/759