### PR TITLE
ts_ci: handle watchdog timeout as a timeout

### DIFF
--- a/ts_ci/runner.py
+++ b/ts_ci/runner.py
@@ -126,27 +126,28 @@ async def _run_test_case(
                 log.error(f"Backend creation failed: {e}")
                 return "fail"
 
-            async with StreamWatchdog(test.no_output_timeout_s, OUTPUT):
-                try:
+            try:
+                async with StreamWatchdog(test.no_output_timeout_s, OUTPUT):
                     await backend.start()
                     await test.run(backend)
-                except EOFError as e:
-                    raise TestFailureException(
-                        "EOF when reading from backend stream"
-                    ) from e
-                except asyncio.IncompleteReadError as e:
-                    raise TestFailureException(
-                        f"EOF when reading from backend stream: {e}"
-                    ) from e
-                except (TimeoutError, asyncio.TimeoutError) as e:
-                    raise TestFailureException("timeout") from e
-                except asyncio.CancelledError:
-                    log.info("cancelling tests...")
-                    raise
 
-                finally:
-                    reset_terminal()
-                    await backend.stop()
+            except EOFError as e:
+                raise TestFailureException(
+                    "EOF when reading from backend stream"
+                ) from e
+            except asyncio.IncompleteReadError as e:
+                raise TestFailureException(
+                    f"EOF when reading from backend stream: {e}"
+                ) from e
+            except (TimeoutError, asyncio.TimeoutError) as e:
+                raise TestFailureException("timeout") from e
+            except asyncio.CancelledError:
+                log.info("cancelling tests...")
+                raise
+
+            finally:
+                reset_terminal()
+                await backend.stop()
 
         except TestFailureException as e:
             log.error(f"Test failed: {e}")


### PR DESCRIPTION
Oops, somehow this was missed:

```
  CI|ERROR: Test failed (internal exception):
  Traceback (most recent call last):
    File "/home/runner/work/sddf/sddf/systems-ci/ts_ci/runner.py", line 131, in _run_test_case
      await backend.start()
    File "/home/runner/work/sddf/sddf/systems-ci/ts_ci/backends/machine_queue.py", line 109, in start
      await wait_for_output(self, self.image_started)
    File "/home/runner/work/sddf/sddf/systems-ci/ts_ci/backends/streams.py", line 19, in wrapper
      return await f(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/runner/work/sddf/sddf/systems-ci/ts_ci/backends/streams.py", line 65, in wait_for_output
      read = await backend.output_stream.read(1)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3.12/asyncio/streams.py", line 713, in read
      await self._wait_for_data('read')
    File "/usr/lib/python3.12/asyncio/streams.py", line 545, in _wait_for_data
      await self._waiter
  asyncio.exceptions.CancelledError
  
  The above exception was the direct cause of the following exception:
  
  Traceback (most recent call last):
    File "/home/runner/work/sddf/sddf/systems-ci/ts_ci/runner.py", line 129, in _run_test_case
      async with StreamWatchdog(test.no_output_timeout_s, OUTPUT):
    File "/home/runner/work/sddf/sddf/systems-ci/ts_ci/stream_watchdog.py", line 118, in __aexit__
      raise TimeoutError from exc_val
  TimeoutError

```
  
  
Observed: https://github.com/au-ts/sddf/actions/runs/31554832677/job/93986117447?pr=760